### PR TITLE
add arg: allow_unsafe=False to json_schema.match()

### DIFF
--- a/json_schema/json_schema.py
+++ b/json_schema/json_schema.py
@@ -123,9 +123,9 @@ def dumps(j, *args, **kwargs):
     return json.dumps(montador(data), *args, **kwargs)
 
 
-def match(j, schema):
+def match(j, schema, allow_unsafe=False):
     """Compara um json (j) com um schema (schema)."""
-    js = JsonSchema(schema)
+    js = JsonSchema(schema, allow_unsafe)
     return js == j
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
     ],
 


### PR DESCRIPTION
@nano-labs I'd like to use python validator by running "json_schema.match(j, schema, allow_unsafe=True)"